### PR TITLE
copy default config

### DIFF
--- a/hitchelasticsearch/elastic_service.py
+++ b/hitchelasticsearch/elastic_service.py
@@ -1,6 +1,6 @@
 from hitchtest.environment import checks
 from hitchserve import Service
-from os.path import join
+from os.path import exists, join
 import signal
 import shutil
 import sys
@@ -13,9 +13,19 @@ class ElasticService(Service):
         kwargs['no_libfaketime'] = True
         super(ElasticService, self).__init__(**kwargs)
 
+    def setup(self):
+        config_dir = join(
+            self.service_group.hitch_dir.hitch_dir, 'elasticconf'
+        )
+        if not exists(config_dir):
+            shutil.copytree(join(
+                self.elastic_package.directory, 'config'
+            ), config_dir)
+
     @Service.command.getter
     def command(self):
         if self._command is None:
+
             return [
                       self.elastic_package.elasticsearch,
                       "--path.data={}".format(join(


### PR DESCRIPTION
On a fresh installation, the installed elasticsearch gets started with no configuration, which cause Elasticsearch to not log much.

Among the lines not logged is the line containing 'started'. This makes it appears as if ES did not start, thus making the tests fail because the build times out waiting for ES to boot up.

The proposed fix address the issue by copying the default configuration over to the `.hitch` directory so that the service will use that.

I wish I could move this logic to the `__init__` method, but it looks like I dont have access to both the paths of `.hitchpkg` and `.hitch` that soon.
